### PR TITLE
Support <input type="radio" name="id[1]">

### DIFF
--- a/js/handsome.js
+++ b/js/handsome.js
@@ -181,7 +181,7 @@ handsome.Radio = (function() {
     };
 
     Radio.prototype.triggerClicked = function() {
-            $('.bt-radio-trigger[data-radioname=' + this.targetRadio.prop('name') + ']').removeClass('checked');
+            $('.bt-radio-trigger[data-radioname="' + this.targetRadio.prop('name') + '"]').removeClass('checked');
             this.radioTrigger.addClass('checked');
             this.radioSisters.prop('checked', false);
             this.targetRadio.prop('checked', true);


### PR DESCRIPTION
When there are sqaure brackets in the radio input's name attribute clicking an option results in a jQuery syntax error becuase Handsome executes
```javascript
$('.bt-radio-trigger[data-radioname=id[1]]').removeClass('checked');
```
With quotes around the name parameter it works.